### PR TITLE
Fix CI workflow bugs and tighten permissions

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -3,16 +3,19 @@ name: Arduino lint
 on:
   push:
     paths:
-      - ".github/workflows/compile-examples.yml"
+      - ".github/workflows/arduino-lint.yml"
       - "examples/**"
       - "src/**"
   pull_request:
     paths:
-      - ".github/workflows/compile-examples.yml"
+      - ".github/workflows/arduino-lint.yml"
       - "examples/**"
       - "src/**"
   workflow_dispatch:
   repository_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -14,6 +14,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   compile-parallel-examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,10 +1,13 @@
 name: Generate documentation
 
 on:
-  pull_request:
+  push:
     branches: [ master ]
 
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   generate-deploy:

--- a/.github/workflows/size-delta-pr.yml
+++ b/.github/workflows/size-delta-pr.yml
@@ -1,8 +1,15 @@
 name: Size delta PR
 
 on:
-  schedule:
-    - cron: '*/10 * * * *'
+  workflow_run:
+    workflows: [ "Compile examples" ]
+    types: [ completed ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
 
 jobs:
   report:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   spell-check:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Spell check
-        uses: codespell-project/actions-codespell@master
+        uses: codespell-project/actions-codespell@v2
         with:
           skip: ./doc/Doxygen/**,./doc/Doxygen/*
 #          exclude_file: "./examples/E_progmem_menu/E_progmem_menu.ino"


### PR DESCRIPTION
- arduino-lint.yml: path filter watched compile-examples.yml instead of itself, so lint changes never triggered the workflow
- doxygen.yml: deploy to gh-pages on push to master instead of on pull_request, which failed for fork PRs and published unmerged docs
- size-delta-pr.yml: trigger via workflow_run off "Compile examples" completion instead of polling every 10 minutes on a cron schedule
- spell-check.yml: pin codespell action to v2 instead of the mutable master ref
- add explicit least-privilege permissions blocks to all five workflows instead of relying on default token scope