### PR TITLE
Add `LiquidSystem::get_currentMenu()`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LiquidMenu
-version=1.6.1
+version=1.6.2
 author=Vasil Kalchev <vase7u@gmail.com>
 maintainer=Vasil Kalchev <vase7u@gmail.com>
 sentence=Menu creation Arduino library for LCDs, wraps LiquidCrystal.

--- a/src/LiquidMenu.h
+++ b/src/LiquidMenu.h
@@ -1159,6 +1159,14 @@ public:
   */
   LiquidScreen* get_currentScreen() const;
 
+  /// Returns a pointer to the current menu.
+  /**
+  Call this method to obtain a pointer to the current menu.
+
+  @returns a pointer to the current menu.
+  */
+  LiquidMenu* get_currentMenu() const;
+
   /// Switches to the next screen.
   void next_screen();
 

--- a/src/LiquidSystem.cpp
+++ b/src/LiquidSystem.cpp
@@ -93,6 +93,10 @@ LiquidScreen* LiquidSystem::get_currentScreen() const {
 	return _p_liquidMenu[_currentMenu]->get_currentScreen();
 }
 
+LiquidMenu* LiquidSystem::get_currentMenu() const {
+	return _p_liquidMenu[_currentMenu];
+}
+
 void LiquidSystem::next_screen() {
 	_p_liquidMenu[_currentMenu]->next_screen();
 }


### PR DESCRIPTION
Adds a getter for the currently active menu, mirroring the existing `get_currentScreen()`. There was previously no way to retrieve which LiquidMenu a LiquidSystem is currently showing.

Closes #109.